### PR TITLE
Ensure pip is up to date

### DIFF
--- a/.github/workflows/daily_check.yml
+++ b/.github/workflows/daily_check.yml
@@ -49,6 +49,7 @@ jobs:
         uses: ./.github/actions/linux_install
       - name: Install python dependencies
         run: |
+          pip3 install --upgrade pip
           pip3 install .
           pip3 freeze > version_specific_results/pypi_performance_3${{ matrix.python-minor-version }}_${{needs.Check_Pyccel_Version.outputs.new_version }}_requirements.txt
       - name: Generate pyccel configs

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -40,6 +40,7 @@ jobs:
         uses: ./.github/actions/linux_install
       - name: Install development version of pyccel from GitHub
         run: |
+          pip3 install --upgrade pip
           pip3 install 'pyccel @ git+https://github.com/pyccel/pyccel'
       - name: Install python dependencies
         run: |


### PR DESCRIPTION
Python 3.12 is incompatible with older versions of pip. It is therefore important to update before installing anything