### PR TITLE
Add a default PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+\<PR description\>
+
+## Checklist
+
+- [ ] CI has been tested by adding a commit containing the message "Benchmark of pyccel"
+     - See commit : XXXXXX
+- [ ] Files modified by the CI have been reverted
+- [ ] If the figure generation has been modified, regress the value in `current_version.txt` to retrigger the results for the most recent version


### PR DESCRIPTION
Add a default PR template with a short checklist containing reminders about how to use the CI. This was discussed in #40.

## Checklist

- [ ] CI has been tested by adding a commit containing the message "Benchmark of pyccel"
     - See commit : XXXXXX
- [ ] Files modified by the CI have been reverted
- [ ] If the figure generation has been modified, regress the value in `current_version.txt` to retrigger the results for the most recent version