### PR TITLE
Update README.md

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -13,9 +13,10 @@ In order to test pyccel and/or pythran, configuration files must be provided. An
 - `-mtune=native`
 - `-mavx`
 - `-ffast-math`
-Pyccel configurations valid for your machine can be generated using the following command (which may be adapted for c generation or other compiler languages, see the [pyccel documentation](https://github.com/pyccel/pyccel/blob/master/tutorial/compiler.md)):
+
+Pyccel configurations valid for your machine can be generated using the following command (which may be adapted for another compiler family, see the [pyccel documentation](https://github.com/pyccel/pyccel/blob/master/tutorial/compiler.md)):
 ```
-pyccel --language=fortran --export-compile-info pyccel_fortran.json
+pyccel --compiler-family intel --export-compiler-config pyccel_intel.json
 ```
 This configuration can then be modified to include additional flags or use different compilers. The tests shown below add the following additional flags (which match the flags added to pythran):
 - `-O3`


### PR DESCRIPTION
In PR #40 the file `README.md` was updated by hand, forgetting that it is generated by the action `create_readme` using the files `intro.md` and `test_details.md`. As a consequence, the changes made to `README.md` were reverted by the first workflow run. Here we finally update`intro.md`, and move it to the folder `benchmarks` together with `test_details.md`.

## Checklist

- [ ] CI has been tested by adding a commit containing the message "Benchmark of pyccel"
     - See commit : XXXXXX
- [ ] Files modified by the CI have been reverted
- [ ] If the figure generation has been modified, regress the value in `current_version.txt` to retrigger the results for the most recent version
